### PR TITLE
either import or require (fa icons issue)

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,7 +11,6 @@
  *= require_self
  *= require normalize
  *= require cartodb
- *= require font-awesome
  *= require base
  *= require_tree .
  */


### PR DESCRIPTION
I think ideally we should not have 'require' and 'import' mixed in the same manifest file anyway, but this is the minimum change required for fa icons to display properly on my end.